### PR TITLE
adiciona endpoint /auth/me para retorno do usuário autenticado

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -13,6 +13,7 @@ from .views import (
     MarcacaoHabitoViewSet,
     RegisterView,
     LoginView,
+    MeView,
 )
 
 router = DefaultRouter()
@@ -29,5 +30,6 @@ urlpatterns = [
     path("healthz/", healthz),
     path("auth/register/", RegisterView.as_view(), name="auth-register"),
     path("auth/login/", LoginView.as_view(), name="auth-login"),
+    path("auth/me/", MeView.as_view(), name="auth-me"),
     path("api/", include(router.urls)),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -181,3 +181,15 @@ class MarcacaoHabitoViewSet(viewsets.ModelViewSet):
             qs = qs.filter(meta_id=meta_id)
 
         return qs
+
+class MeView(APIView):
+    """
+    Retorna os dados do usuário autenticado.
+    GET /auth/me/
+    """
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        user = request.user  # vem do JWTAuthentication
+        serializer = UsuarioSerializer(user)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
#Implementa o endpoint /auth/me que retorna os dados do usuário autenticado a partir do token JWT.
Criada MeView em views.py com IsAuthenticated.
Rota adicionada em urls.py.
Retorno via UsuarioSerializer.
Testado via Insomnia, com respostas 200 (token válido) e 401 (token ausente/inválido).

