### PR TITLE
Feat: Implementa CRUD de Metas de Hábito

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -78,7 +78,7 @@ class SerieMusculacaoSerializer(serializers.ModelSerializer):
             "carga_kg",
         ]
 
-
+# =================== Meta Hábito =======================
 class MetaHabitoSerializer(serializers.ModelSerializer):
     usuario = serializers.PrimaryKeyRelatedField(read_only=True)
     class Meta:
@@ -98,6 +98,22 @@ class MetaHabitoSerializer(serializers.ModelSerializer):
             "criado_em",
         ]
 
+    def validate(self, data):
+        # Para PUT/PATCH, se o campo não estiver no 'data', usa o valor existente (self.instance)
+        is_update = self.instance is not None
+        
+        # Recupera data_inicio e data_fim, priorizando o dado do 'data' ou o valor existente (self.instance)
+        data_inicio = data.get('data_inicio', self.instance.data_inicio if is_update else None)
+        data_fim = data.get('data_fim', self.instance.data_fim if is_update else None)
+        
+        # Valida se data_fim é menor que data_inicio
+        if data_inicio and data_fim and data_fim < data_inicio:
+            raise serializers.ValidationError(
+                {"data_fim": "A data final do hábito não pode ser anterior à data de início."}
+            )
+            
+        return data
+# =================== Carlos e Abelardo =====================
 
 class MarcacaoHabitoSerializer(serializers.ModelSerializer):
     usuario = serializers.PrimaryKeyRelatedField(read_only=True)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -180,6 +180,13 @@ class MetaHabitoViewSet(viewsets.ModelViewSet):
             qs = qs.filter(ativo=ativo)
 
         return qs
+    
+    def perform_destroy(self, instance):
+        if instance.marcacoes.exists():
+            instance.ativo = False
+            instance.save()
+        else:
+            instance.delete()
 
 
 class MarcacaoHabitoViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
# Este PR implementa a funcionalidade completa de CRUD (Criar, Ler, Atualizar, Deletar) para o recurso de MetaHabito, fechando a issue feat/metas_habito.

Isso permite que o usuário autenticado gerencie suas próprias metas de hábito de forma segura, garantindo que ele só possa ver e modificar seus próprios dados.

Principais Alterações Implementadas
views.py (MetaHabitoViewSet):

Segurança (Leitura): O método get_queryset foi implementado com .filter(usuario=request.user) para garantir que um usuário só possa listar/ver suas próprias metas (retorna 404 se tentar acessar metas de outros).

Segurança (Escrita): O método perform_create garante que o usuario seja automaticamente definido como o usuário logado durante a criação (POST), ignorando qualquer dado vindo do body.

Exclusão Lógica (Soft Delete): O método perform_destroy foi sobrescrito:

Se a meta tiver MarcacaoHabito associadas, ela é apenas desativada (ativo=False).

Se a meta estiver "limpa" (sem marcações), ela é excluída permanentemente (.delete()).

serializers.py (MetaHabitoSerializer):

Validação de Negócio: Adicionado o método validate para impedir o cadastro de metas onde a data_fim seja anterior à data_inicio.

# urls.py:
A rota api/metas-habito/ foi registrada no DefaultRouter para expor o MetaHabitoViewSet.

Como Testar (Testes Manuais via Insomnia):
Todos os testes devem ser feitos com um Token JWT válido (Auth > Bearer Token).

# POST /api/metas-habito/
Teste 1 (Sucesso): Enviar um JSON válido (Ex: com titulo, modalidade, data_inicio).
- Resultado Esperado: 201 Created.
Teste 2 (Falha Validação): Enviar data_fim anterior à data_inicio.
- Resultado Esperado: 400 Bad Request com a mensagem de erro de data.

# GET /api/metas-habito/
- Resultado Esperado: 200 OK. Retorna apenas a lista de metas do usuário autenticado.

# GET /api/metas-habito/{id}/
- Resultado Esperado: 200 OK (se for o dono) ou 404 Not Found (se a meta não existir ou pertencer a outro usuário).

# PATCH /api/metas-habito/{id}/
- Enviar {"ativo": false}.
 -Resultado Esperado: 200 OK, com a meta atualizada.

# DELETE /api/metas-habito/{id}/
- Resultado Esperado: 204 No Content (como atualmente não há marcações, a exclusão é física).