### PR TITLE
Feature/metricas ciclismo e corrida

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -10,6 +10,7 @@ from .models import (
     SerieMusculacao,
     MetaHabito,
     MarcacaoHabito,
+    ModalidadeChoices,
 )
 
 
@@ -64,7 +65,26 @@ class MetricasCorridaSerializer(serializers.ModelSerializer):
             "fc_media",
         ]
 
+    def validate_sessao(self, sessao):
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
 
+        if user is None or not user.is_authenticated:
+            return sessao
+
+        if sessao.usuario != user:
+            raise serializers.ValidationError(
+                "Você não pode registrar métricas para sessões de outro usuário."
+            )
+
+        if sessao.modalidade != ModalidadeChoices.CORRIDA:
+            raise serializers.ValidationError(
+                "A sessão associada deve ser de modalidade corrida."
+            )
+
+        return sessao
+
+    
 class MetricasCiclismoSerializer(serializers.ModelSerializer):
     class Meta:
         model = MetricasCiclismo
@@ -75,6 +95,24 @@ class MetricasCiclismoSerializer(serializers.ModelSerializer):
             "fc_media",
         ]
 
+    def validate_sessao(self, sessao):
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+
+        if user is None or not user.is_authenticated:
+            return sessao
+
+        if sessao.usuario != user:
+            raise serializers.ValidationError(
+                "Você não pode registrar métricas para sessões de outro usuário."
+            )
+
+        if sessao.modalidade != ModalidadeChoices.CICLISMO:
+            raise serializers.ValidationError(
+                "A sessão associada deve ser de modalidade ciclismo."
+            )
+
+        return sessao
 
 class SerieMusculacaoSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -177,12 +177,26 @@ class SessaoAtividadeViewSet(viewsets.ModelViewSet):
 class MetricasCorridaViewSet(viewsets.ModelViewSet):
     queryset = MetricasCorrida.objects.select_related("sessao").all()
     serializer_class = MetricasCorridaSerializer
-
+    
+    def get_queryset(self):
+        request = cast(Request, self.request)
+        return (
+            MetricasCorrida.objects
+            .select_related("sessao")
+            .filter(sessao__usuario=request.user)
+        )
 
 class MetricasCiclismoViewSet(viewsets.ModelViewSet):
     queryset = MetricasCiclismo.objects.select_related("sessao").all()
     serializer_class = MetricasCiclismoSerializer
-
+    
+    def get_queryset(self):
+            request = cast(Request, self.request)
+            return (
+                MetricasCiclismo.objects
+                .select_related("sessao")
+                .filter(sessao__usuario=request.user)
+            )
 
 class SerieMusculacaoViewSet(viewsets.ModelViewSet):
     queryset = SerieMusculacao.objects.select_related("sessao", "exercicio").all()


### PR DESCRIPTION
### Principais mudanças

- Implementado `MetricasCorridaViewSet` em `/api/metricas-corrida/` com:
  - `POST /api/metricas-corrida/`
  - `GET /api/metricas-corrida/`
  - `GET /api/metricas-corrida/{id}/`
  - `PUT /api/metricas-corrida/{id}/`
  - `PATCH /api/metricas-corrida/{id}/`
  - `DELETE /api/metricas-corrida/{id}/`
- Implementado `MetricasCiclismoViewSet` em `/api/metricas-ciclismo/` com os mesmos verbos HTTP.
- `get_queryset()` de ambos os viewsets filtrando por `sessao__usuario=request.user`, garantindo que o usuário só acesse métricas das próprias sessões.
- Adicionadas validações nos serializers:
  - `MetricasCorridaSerializer.validate_sessao`:
    - impede uso de sessão de outro usuário;
    - impede criação/edição de métricas se a sessão não for de modalidade **corrida**.
  - `MetricasCiclismoSerializer.validate_sessao`:
    - impede uso de sessão de outro usuário;
    - impede criação/edição de métricas se a sessão não for de modalidade **ciclismo**.

### Regras de negócio atendidas

- Não é possível criar métricas de corrida em sessão que não seja corrida.
- Não é possível criar métricas de ciclismo em sessão de outra modalidade.
- Usuário não consegue visualizar nem manipular métricas de sessões de outros usuários.