### PR TITLE
crud de exercicios fisico + novo squema com nome, grupo muscular e eq…

### DIFF
--- a/db/init/02_seed_exercicios.sql
+++ b/db/init/02_seed_exercicios.sql
@@ -1,0 +1,46 @@
+INSERT INTO exercicios (nome, grupo_muscular, equipamento) VALUES
+  -- Peito
+  ('Supino reto com barra', 'Peito', 'Barra e banco'),
+  ('Supino inclinado com halteres', 'Peito', 'Halteres e banco'),
+  ('Crucifixo reto com halteres', 'Peito', 'Halteres e banco'),
+  ('Peck deck', 'Peito', 'Máquina peck deck'),
+
+  -- Costas
+  ('Remada curvada', 'Costas', 'Barra'),
+  ('Remada unilateral com halter', 'Costas', 'Halteres'),
+  ('Puxada na frente', 'Costas', 'Máquina de puxada'),
+  ('Puxada fechada supinada', 'Costas', 'Máquina de puxada'),
+
+  -- Pernas
+  ('Agachamento livre', 'Pernas', 'Barra e rack'),
+  ('Agachamento hack', 'Pernas', 'Máquina hack'),
+  ('Leg press 45º', 'Pernas', 'Máquina leg press'),
+  ('Cadeira extensora', 'Pernas', 'Máquina extensora'),
+  ('Cadeira flexora', 'Pernas', 'Máquina flexora'),
+  ('Avanço com halteres', 'Pernas', 'Halteres'),
+
+  -- Ombros
+  ('Desenvolvimento militar com barra', 'Ombros', 'Barra'),
+  ('Desenvolvimento com halteres sentado', 'Ombros', 'Halteres e banco'),
+  ('Elevação lateral', 'Ombros', 'Halteres'),
+  ('Elevação frontal', 'Ombros', 'Halteres'),
+
+  -- Bíceps
+  ('Rosca direta', 'Bíceps', 'Barra'),
+  ('Rosca alternada', 'Bíceps', 'Halteres'),
+  ('Rosca martelo', 'Bíceps', 'Halteres'),
+
+  -- Tríceps
+  ('Tríceps testa', 'Tríceps', 'Barra ou halteres'),
+  ('Tríceps na polia alta', 'Tríceps', 'Polia'),
+  ('Mergulho entre bancos', 'Tríceps', 'Bancos'),
+
+  -- Abdômen
+  ('Prancha isométrica', 'Abdômen', 'Colchonete'),
+  ('Crunch no solo', 'Abdômen', 'Colchonete'),
+  ('Elevação de pernas na barra fixa', 'Abdômen', 'Barra fixa'),
+
+  -- Glúteos / Panturrilhas
+  ('Elevação de quadril no banco', 'Glúteos', 'Banco'),
+  ('Elevação de panturrilha em pé', 'Panturrilhas', 'Máquina ou peso corporal'),
+  ('Elevação de panturrilha sentado', 'Panturrilhas', 'Máquina');


### PR DESCRIPTION
### O que foi implementado

1. **Esquema / Banco**
- Ajuste/criação da tabela `exercicios` com os campos:
  - `nome`
  - `grupo_muscular`
  - `equipamento`
- Seed automático no Postgres via scripts em `db/init`, populando um catálogo inicial de exercícios:
  - Peito, costas, pernas, ombros, bíceps, tríceps, abdômen, glúteos e panturrilhas.
- Ao subir o `docker compose` do banco pela primeira vez, o catálogo já é criado para todos os devs.

2. **Catálogo de exercícios**
- Exposição do endpoint `/api/exercicios/` para listar exercícios cadastrados.
- Suporte a busca por `nome`, `grupo_muscular` e `equipamento` via query string.

3. **CRUD de séries de musculação**
- ViewSet de `SerieMusculacao` em `/api/series-musculacao/` com:
  - `POST /api/series-musculacao/`
  - `GET /api/series-musculacao/` (com filtros por `sessao_id` e `exercicio_id`)
  - `GET /api/series-musculacao/{id}/`
  - `PUT/PATCH /api/series-musculacao/{id}/`
  - `DELETE /api/series-musculacao/{id}/`
- Regras de negócio:
  - Só permite criar/editar séries em sessões que pertencem ao usuário autenticado.
  - Só aceita sessões com modalidade **`musculacao`**.
  - `ordem_serie`:
    - deve ser ≥ 1;
    - não pode se repetir dentro da mesma sessão.
  - Se `ordem_serie` não for enviada, o backend calcula automaticamente a próxima ordem (1, 2, 3…).
  - Após um `DELETE`, as séries restantes da sessão têm a `ordem_serie` reindexada sequencialmente (1, 2, 3…).

### Como testar

1. Subir o ambiente:
   - `docker compose down -v`
   - `docker compose up -d --build`