### PR TITLE
renovação automática do token

### DIFF
--- a/backend/core/authentication.py
+++ b/backend/core/authentication.py
@@ -9,11 +9,9 @@ from .models import Usuario
 
 
 def create_jwt_for_user(user: Usuario) -> str:
-    """
-    Cria um token JWT simples contendo o ID e o e-mail do usuário.
-    """
+
     now = datetime.now(timezone.utc)
-    lifetime_minutes = getattr(settings, "JWT_ACCESS_TOKEN_LIFETIME_MINUTES", 60)
+    lifetime_minutes = getattr(settings, "JWT_ACCESS_TOKEN_LIFETIME_MINUTES", 15)
     exp = now + timedelta(minutes=lifetime_minutes)
 
     payload = {
@@ -32,21 +30,16 @@ def create_jwt_for_user(user: Usuario) -> str:
 
 
 class JWTAuthentication(BaseAuthentication):
-    """
-    Autenticação baseada em JWT usando o header:
-    Authorization: Bearer <token>
-    """
 
     keyword = "Bearer"
 
     def authenticate(self, request):
         auth_header = request.headers.get("Authorization")
         if not auth_header:
-            return None  # Retorna None se o header estiver ausente ou mal formatado.
+            return None 
 
         parts = auth_header.split()
-        
-        # Correção para garantir que a comparação seja case-insensitive (boa prática)
+
         if len(parts) != 2 or parts[0].lower() != self.keyword.lower():
             return None
 
@@ -75,10 +68,5 @@ class JWTAuthentication(BaseAuthentication):
         return (user, None)
 
     def authenticate_header(self, request):
-        """
-        Retorna o cabeçalho WWW-Authenticate.
-        Isso instrui o cliente sobre o esquema de autenticação (Bearer)
-        e garante que o DRF retorne 401 Unauthorized quando authenticate()
-        retorna None (token ausente ou inválido).
-        """
+
         return 'Bearer realm="api"'

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,6 +15,7 @@ from .views import (
     LoginView,
     ChangePasswordView,
     MeView,
+    RefreshTokenView,
 )
 
 router = DefaultRouter()
@@ -33,5 +34,6 @@ urlpatterns = [
     path("auth/login/", LoginView.as_view(), name="auth-login"),
     path("auth/me/", MeView.as_view(), name="auth-me"),
     path("auth/change-password/", ChangePasswordView.as_view(), name="change-password"),
+    path("auth/refresh/", RefreshTokenView.as_view(), name="auth-refresh"),
     path("api/", include(router.urls)),
 ]


### PR DESCRIPTION
### Contexto
Implementar fluxo de autenticação com **access token de curta duração** e **refresh token de longa duração**, permitindo renovar o access token sem novo login.

### O que foi feito
- Criação de **refresh token JWT** (`create_refresh_token` / `decode_refresh_token`) com:
  - `sub` (id do usuário), `type = "refresh"`, `iat`, `exp` (7 dias).
- Ajustes nos endpoints:
  - `POST /auth/register/` e `POST /auth/login/` agora retornam:
    - `user`, `access_token`, `refresh_token`.
- Novo endpoint:
  - `POST /auth/refresh/`
    - Recebe `{ "refresh_token": "<token>" }`
    - Valida o refresh e devolve **novo `access_token`**.
- `create_jwt_for_user`:
  - Usa `JWT_ACCESS_TOKEN_LIFETIME_MINUTES` para definir expiração do access token.
- `/auth/me/`:
  - `GET` dados do usuário.
  - `PATCH` atualização parcial de dados.
  - `DELETE` exclusão da própria conta.
