### PR TITLE
feat: Implementa encerramento de metas (Soft Delete) e filtro de ativos

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -350,7 +350,15 @@ class MetaHabitoViewSet(viewsets.ModelViewSet):
         serializer.save(usuario=self.request.user)
 
     def perform_update(self, serializer):
-        serializer.save(usuario=self.request.user)
+        dados_recebidos = serializer.validated_data
+        
+        novo_status_ativo = dados_recebidos.get('ativo')
+
+        if novo_status_ativo is True and 'data_fim' not in dados_recebidos:
+            serializer.save(usuario=self.request.user, data_fim=None)
+        
+        else:
+            serializer.save(usuario=self.request.user)
 
     @action(detail=True, methods=['patch'])
     def encerrar(self, request, pk=None):


### PR DESCRIPTION
O que este PR faz?
Implementa a funcionalidade de "Encerrar Meta", permitindo que o usuário desative uma meta de hábito sem perder o histórico de marcações. Além disso, melhora a experiência do usuário (UX) filtrando automaticamente as metas inativas da listagem principal.

Principais Alterações
views.py (MetaHabitoViewSet):

Nova Ação @action encerrar:

Cria o endpoint PATCH /api/metas-habito/{id}/encerrar/.

Define ativo = False.

Define data_fim como a data atual (hoje), mantendo a consistência dos dados.

Melhoria no get_queryset:

Agora, a listagem padrão (GET /api/metas-habito/) retorna apenas metas ativas (ativo=True).

Para ver o histórico, o front-end pode passar ?ativo=false.

Ações de edição/detalhe continuam acessíveis para metas inativas (para permitir reativação).

Lógica de Reativação (perform_update):

Ao reativar uma meta (ativo=True), o sistema limpa automaticamente a data_fim (define como null) para evitar que a meta renasça já vencida.

Como Testar (Insomnia)
Pré-requisito: Estar logado (Bearer Token).

Criar Meta:

POST /api/metas-habito/ -> Retorna 201.

Listar:

GET /api/metas-habito/ -> A meta deve aparecer.

Encerrar:

PATCH /api/metas-habito/{id}/encerrar/ -> Retorna 200, com ativo: false e data_fim preenchida.

Verificar Listagem (UX):

GET /api/metas-habito/ -> A meta NÃO deve mais aparecer na lista.

Reativar (Opcional):

PATCH /api/metas-habito/{id}/ com {"ativo": true} -> Retorna 200 e data_fim: null.