### PR TITLE
feat: Implementa endpoint de Resumo do Dashboard

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -16,6 +16,7 @@ from .views import (
     ChangePasswordView,
     MeView,
     RefreshTokenView,
+    DashboardResumoView,
 )
 
 router = DefaultRouter()
@@ -35,5 +36,6 @@ urlpatterns = [
     path("auth/me/", MeView.as_view(), name="auth-me"),
     path("auth/change-password/", ChangePasswordView.as_view(), name="change-password"),
     path("auth/refresh/", RefreshTokenView.as_view(), name="auth-refresh"),
+    path("api/dashboard/resumo/", DashboardResumoView.as_view(), name="dashboard-resumo"),
     path("api/", include(router.urls)),
 ]


### PR DESCRIPTION
Adiciona o endpoint GET /api/dashboard/resumo/ que calcula métricas de atividades do usuário.

Alterações:

Criação da DashboardResumoView usando agregações do Django (Sum, Avg, Count) para alta performance.

Cálculo de totais (tempo, calorias, sessões) e médias específicas por modalidade (ritmo, velocidade).

Suporte a filtro por período (?dias=X).